### PR TITLE
Use forked vue-cli-plugin-apollo

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "cross-fetch": "^3.0.6",
     "universal-cookie": "^4.0.4",
     "vue-apollo": "^3.0.5",
-    "vue-cli-plugin-apollo": "^0.22.2",
+    "vue-cli-plugin-apollo": "https://github.com/octoopi/vue-cli-plugin-apollo.git",
     "webpack-node-externals": "^2.5.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
Now that we pushed to production, we can merge this so the Octoo repo uses the main branch of this dependency again:

```
"@nuxtjs/apollo": "https://github.com/octoopi/apollo-module.git",
```

Instead of the current:

```
"@nuxtjs/apollo": "https://github.com/octoopi/apollo-module.git#forked-vue-cli-plugin-apollo",
```